### PR TITLE
feat: Add reference subfolder to out pack

### DIFF
--- a/tre-judgment-packer/tre_judgment_packer.py
+++ b/tre-judgment-packer/tre_judgment_packer.py
@@ -92,6 +92,7 @@ def handler(event, context):
             s3_bucket_in=s3_source_bucket,
             s3_object_names=files_to_zip,
             tar_gz_object=s3_file_path_with_file_name,
+            tar_internal_prefix=reference,
             s3_bucket_out=OUT_BUCKET,
         )
 

--- a/tre-judgment-packer/tre_judgment_packer.py
+++ b/tre-judgment-packer/tre_judgment_packer.py
@@ -92,7 +92,7 @@ def handler(event, context):
             s3_bucket_in=s3_source_bucket,
             s3_object_names=files_to_zip,
             tar_gz_object=s3_file_path_with_file_name,
-            tar_internal_prefix=reference,
+            tar_internal_prefix=f"{reference}/",
             s3_bucket_out=OUT_BUCKET,
         )
 


### PR DESCRIPTION
This ensures that files in the final package produced are all enclosed in a folder named as the original request reference, as per request from FCL.

[Jira Card](https://national-archives.atlassian.net/jira/software/projects/DTE/boards/57)

## Test Plan

Built new image based on changes, integrated into local pte, confirmed subfolder present in out pack