### PR TITLE
Missing cgi

### DIFF
--- a/tre-judgment-packer/Dockerfile
+++ b/tre-judgment-packer/Dockerfile
@@ -12,5 +12,6 @@ RUN dnf upgrade
 RUN dnf clean all --enablerepo=\*
 RUN pip3 install --requirement requirements.txt --target "${LAMBDA_TASK_ROOT}"
 
+RUN pip3 install cgi
 # Set the CMD to your handler (could also be done as a parameter override outside of the Dockerfile)
 CMD [ "tre_judgment_packer.handler" ]

--- a/tre-judgment-packer/Dockerfile
+++ b/tre-judgment-packer/Dockerfile
@@ -12,6 +12,6 @@ RUN dnf upgrade
 RUN dnf clean all --enablerepo=\*
 RUN pip3 install --requirement requirements.txt --target "${LAMBDA_TASK_ROOT}"
 
-RUN pip3 install cgi
+RUN pip install legacy-cgi
 # Set the CMD to your handler (could also be done as a parameter override outside of the Dockerfile)
 CMD [ "tre_judgment_packer.handler" ]

--- a/tre-judgment-packer/Dockerfile
+++ b/tre-judgment-packer/Dockerfile
@@ -12,6 +12,6 @@ RUN dnf upgrade
 RUN dnf clean all --enablerepo=\*
 RUN pip3 install --requirement requirements.txt --target "${LAMBDA_TASK_ROOT}"
 
-RUN pip install --no-cache-dir legacy-cgi=2.6.2
+RUN pip install --no-cache-dir legacy-cgi==2.6.2
 # Set the CMD to your handler (could also be done as a parameter override outside of the Dockerfile)
 CMD [ "tre_judgment_packer.handler" ]

--- a/tre-judgment-packer/Dockerfile
+++ b/tre-judgment-packer/Dockerfile
@@ -12,6 +12,6 @@ RUN dnf upgrade
 RUN dnf clean all --enablerepo=\*
 RUN pip3 install --requirement requirements.txt --target "${LAMBDA_TASK_ROOT}"
 
-RUN pip install legacy-cgi
+RUN pip install --no-cache-dir legacy-cgi=2.6.2
 # Set the CMD to your handler (could also be done as a parameter override outside of the Dockerfile)
 CMD [ "tre_judgment_packer.handler" ]


### PR DESCRIPTION
cgi package, which was removed from Python 3.13
need to add with PIP
udpated with wiz scan fixes