### PR TITLE
Pin third-party actions to commit SHAs

### DIFF
--- a/.github/workflows/build-deploy-and-tag-ecr-image.yml
+++ b/.github/workflows/build-deploy-and-tag-ecr-image.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 jobs:
   ecr-deploy:
-    uses: nationalarchives/da-tre-github-actions/.github/workflows/docker-build-and-ecr-deploy-using-code-artifact.yml@0.0.78
+    uses: nationalarchives/da-tre-github-actions/.github/workflows/docker-build-and-ecr-deploy-using-code-artifact.yml@af45be0b48a6c746708245beaa3023fd36a5b217 # 0.0.78
     with:
       docker_image_name: 'tre-judgment-packer'
       build_dir: 'tre-judgment-packer'


### PR DESCRIPTION
This PR pins third-party GitHub Actions to full commit SHAs for supply-chain security.

This has been done automatically by [pinact](https://github.com/suzuki-shunsuke/pinact). When reviewing please confirm that the SHAs are correct, zizmor will alert if not.

As a maintainer, please merge this PR once approved.